### PR TITLE
fix <code lang-ext> syntax

### DIFF
--- a/syntax/code.php
+++ b/syntax/code.php
@@ -45,10 +45,8 @@ class syntax_plugin_codeprettify_code extends DokuWiki_Syntax_Plugin {
                 $match = substr($match, 5, -1);
                 list($params, $title) = explode('|', $match);
                 $class['prettify'] = 'prettyprint';
-                if (preg_match('/^[: ]+(\w+)/', $params, $m)) {
+                if (preg_match('/^[: ](?:lang[-:])?(\w+)/', $params, $m)) {
                     if ($m[1] != "linenums") $class['language'] = 'lang-'.$m[1];
-                } elseif (preg_match('/lang-\w+/', $params, $m)) {
-                    $class['language'] = $m[0];
                 }
                 if (preg_match('/linenums(:\d+)?/', $params, $m)) {
                     $class['linenums'] = $m[0];


### PR DESCRIPTION
The `<code lang-ext>` syntax wasn't working because the `elseif` block intended to match it is never reached. I fixed it by combining the two cases into a single `preg_match` that allows for any of these syntaxes.

```
<code:ext>
<code:lang-ext>
<code ext>
<code lang-ext>
<code lang:ext>
```
