### PR TITLE
revise <code> regex

### DIFF
--- a/syntax/code.php
+++ b/syntax/code.php
@@ -43,7 +43,7 @@ class syntax_plugin_codeprettify_code extends DokuWiki_Syntax_Plugin {
                 $match = substr($match, 5, -1);
                 list($params, $title) = explode('|', $match);
                 $class['prettify'] = 'prettyprint';
-                if (preg_match('/(?:^[: ](?!linenums)|(?: lang[-:]))(\w+)/', $params, $m)) {
+                if (preg_match('/(?:^:| (?:lang[-:])?)(?!linenums)(\w+)/', $params, $m)) {
                     $class['language'] = 'lang-'.$m[1];
                 }
                 if (preg_match('/ linenums(:\d+)?/', $params, $m)) {


### PR DESCRIPTION
Allow any of the following syntaxes:
`<code:ext>`
`<code ext>`
`<code lang:ext>`
`<code lang-ext>`
`<code:ext linenums>`
`<code ext linenums>`
`<code lang:ext linenums>`
`<code lang-ext linenums>`
`<code linenums ext>`
`<code linenums lang:ext>`
`<code linenums lang-ext>`
but not:
`<code:lang-ext>`
