### PR TITLE
Title formatting

### DIFF
--- a/code-prettify/src/lang-ex.js
+++ b/code-prettify/src/lang-ex.js
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright (C) 2017 Jacek Królikowski
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview
+ * Registers a language handler for Elixir.
+ *
+ * @author nietaki@gmail.com
+ */
+
+PR['registerLangHandler'](
+    PR['createSimpleLexer'](
+        [
+         [PR['PR_PLAIN'], /^[\t\n\r \xA0]+/, null, '\t\n\r \xA0'],
+         // # comments
+         [PR['PR_COMMENT'], /^#.*/, null, '#'],
+         // a (possibly multiline) charlist
+         [PR['PR_LITERAL'], /^'(?:[^'\\]|\\(?:.|\n|\r))*'?/, null, '\''],
+         // @attributes
+         [PR['PR_ATTRIB_NAME'], /^@\w+/, null, '@'],
+         [PR['PR_PUNCTUATION'], /^[!%&()*+,\-;<=>?\[\\\]^{|}]+/, null,
+          '!%&()*+,-;<=>?[\\]^{|}'],
+         // Borrowed from lang-erlang.js:
+         [PR['PR_LITERAL'],
+          /^(?:0o[0-7](?:[0-7]|_[0-7])*|0x[\da-fA-F](?:[\da-fA-F]|_[\da-fA-F])*|\d(?:\d|_\d)*(?:\.\d(?:\d|_\d)*)?(?:[eE][+\-]?\d(?:\d|_\d)*)?)/,
+          null, '0123456789']
+        ],
+        [
+         // the iex> prompt for interactive examples
+         [PR['PR_ATTRIB_NAME'], /^iex(?:\(\d+\))?> /],
+         // special case for binaries, so that they don't get presented like atoms
+         [PR['PR_PUNCTUATION'], /^::/],
+         // atoms - :__a_word or :"colon followed by a string"
+         [PR['PR_LITERAL'], /^:(?:\w+[\!\?\@]?|"(?:[^"\\]|\\.)*"?)/],
+         // compile-time information
+         [PR['PR_ATTRIB_NAME'], /^(?:__(?:CALLER|ENV|MODULE|DIR)__)/],
+         // keywords
+         [PR['PR_KEYWORD'],
+          /^(?:alias|case|catch|def(?:delegate|exception|impl|macrop?|module|overridable|p?|protocol|struct)|do|else|end|fn|for|if|in|import|quote|raise|require|rescue|super|throw|try|unless|unquote(?:_splicing)?|use|when|with|yield)\b/],
+         [PR['PR_LITERAL'], /^(?:true|false|nil)\b/],
+         // atoms as keyword list keys
+         // NOTE: this does also handle the %{"I'm an atom": :foo} case
+         //
+         // Contains negative lookahead to handle <<foo::binary>>
+         [PR['PR_LITERAL'], /^(?:\w+[\!\?\@]?|"(?:[^"\\]|\\.)*"):(?!:)/],
+         // heredoc: triple double-quoted multi-line string.
+         //
+         // NOTE: the opening """ needs to be followed by a newline
+         [PR['PR_STRING'],
+          /^"""\s*(\r|\n)+(?:""?(?!")|[^\\"]|\\(?:.|\n|\r))*"{0,3}/],
+         // A double-quoted multi-line string
+         [PR['PR_STRING'],
+          /^"(?:[^"\\]|\\(?:.|\n|\r))*"?(?!")/],
+         // types
+         [PR['PR_TYPE'], /^[A-Z]\w*/],
+         // variables not meant to be used or private functions
+         [PR['PR_COMMENT'], /^_\w*/],
+         // plain: variables, functions, ...
+         [PR['PR_PLAIN'], /^[$a-z]\w*[\!\?]?/],
+         // sigils with the same starting and ending character.
+         // Key part: X(?:[^X\r\n\\]|\\.)+X where X is the sigil character
+         [PR['PR_ATTRIB_VALUE'], /^~[A-Z](?:\/(?:[^\/\r\n\\]|\\.)+\/|\|(?:[^\|\r\n\\]|\\.)+\||"(?:[^"\r\n\\]|\\.)+"|'(?:[^'\r\n\\]|\\.)+')[A-Z]*/i],
+         // sigils with a different starting and ending character.
+         // Key part: X(?:[^Y\r\n\\]|\\.)+Y where X and Y are the starting and ending characters
+         [PR['PR_ATTRIB_VALUE'], /^~[A-Z](?:\((?:[^\)\r\n\\]|\\.)+\)|\[(?:[^\]\r\n\\]|\\.)+\]|\{(?:[^\}\r\n\\]|\\.)+\}|\<(?:[^\>\r\n\\]|\\.)+\>)[A-Z]*/i],
+         [PR['PR_PUNCTUATION'], /^(?:\.+|\/|[:~])/]
+        ]),
+    ['ex','exs']);

--- a/code-prettify/styles/demo.html
+++ b/code-prettify/styles/demo.html
@@ -1,47 +1,90 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
-<html><head>
+<!DOCTYPE html>
+<html>
+<head>
+<title>Demo</title>
 <script src="../src/prettify.js"></script>
 <script src="../src/lang-css.js"></script>
-<style>
-body { margin: 0; padding: 0 }
-pre { margin: 0 }
+<style type="text/css">
+body { margin: 0; padding: 0; }
+pre { margin: 0; }
+#container { width: 40em; display: inline-block; }
 </style>
-</head>
-<script>
-// This page displays some code styled using a theme named in the
-// query part of the URL.
-var themeName = decodeURIComponent(document.location.search.replace(/^\?/, ''));
-
-// Call out to the parent so that it can resize the iframe once this
-// document's body is loaded.
-function adjustHeightInParent() {
+<script type="text/javascript">
+/**
+ * Call out to the parent so that it can resize the iframe once this
+ * document's body is loaded.
+ * @param {string} theme
+ */
+function adjustHeightInParent(theme) {
   if (parent !== window) {
     try {
-      var div = document.body.getElementsByTagName('div')[0];
-      parent.adjustChildIframeSize(
-          themeName, div.offsetWidth, div.offsetHeight);
+      var div = document.getElementById('container');
+      parent.adjustChildIframeSize(theme, div.offsetWidth, div.offsetHeight);
     } catch (ex) {
       // Can happen when this page is opened in its own tab.
     }
+  } else {
+    // redirect to main page if this page is loaded directly
+    window.location = "./index.html";
   }
 }
 
-// Load the necessary CSS
-(function () {
-  document.title = 'Theme ' + themeName;
-  // Load the stylesheet that we're demoing.
+/**
+ * Theme name is specified by iframe in which the page is loaded
+ * @return {string}
+ */
+function getThemeName() {
+  // theme is named in the query part of the URL
+  //var theme = decodeURIComponent(document.location.search.substring(1));
+
+  // theme is named in the "name" property of the embedded iframe
+  var theme = window.frameElement && window.frameElement.getAttribute("name");
+
+  return theme ? theme : 'default';
+}
+
+/**
+ * Load the necessary CSS
+ * @param {string} theme
+ */
+function loadTheme(theme) {
   var link = document.createElement('link');
   link.rel = 'stylesheet';
   link.type = 'text/css';
-  link.href = themeName === 'default'
-      ? '../src/prettify.css' : themeName + '.css';
+  link.href = theme === 'default' ? '../src/prettify.css' : theme + '.css';
   document.getElementsByTagName('head')[0].appendChild(link);
+}
+
+/**
+ * Called on page load.
+ * This page displays some code styled using theme specified.
+ */
+function onLoadFcn() {
+  // syntax highlight
+  PR.prettyPrint();
+
+  // call to parent we're embedded into
+  var theme = getThemeName();
+  adjustHeightInParent(theme);
+}
+
+(function () {
+  // Load the stylesheet that we're demoing.
+  var themeName = getThemeName();
+  document.title = 'Theme ' + themeName;
+  loadTheme(themeName);
 })();
 </script>
+</head>
 
-<body onload="prettyPrint(); adjustHeightInParent()">
-<div style="width: 40em; display: inline-block">
+<body onload="onLoadFcn();">
+
+<div id="container">
 <pre class="prettyprint lang-html linenums">
+&lt;!doctype html&gt;
+&lt;html&gt;
+&lt;head&gt;
+&lt;title&gt;HTML Test&lt;/title&gt;
 &lt;script type="text/javascript"&gt;
 // Say hello world until the user starts questioning
 // the meaningfulness of their existence.
@@ -51,11 +94,18 @@ function helloWorld(world) {
   }
 }
 &lt;/script&gt;
-&lt;style&gt;
+&lt;style type="text/css"&gt;
 p { color: pink }
 b { color: blue }
 u { color: "umber" }
 &lt;/style&gt;
+&lt;/head&gt;
+&lt;body&gt;
+&lt;h1&gt;Hello world!&lt;/h1&gt;
+&lt;/body&gt;
+&lt;/html&gt;
 </pre>
 </div>
-</body></html>
+
+</body>
+</html>

--- a/code-prettify/styles/index.html
+++ b/code-prettify/styles/index.html
@@ -1,39 +1,73 @@
 <!DOCTYPE html>
-<html><head>
+<html>
+<head>
 <title>Prettify Themes Gallery</title>
 <style type="text/css">
-iframe { width: 100%; border-style: none; margin: 0; padding: 0 }
+iframe { width: 100%; border-style: none; margin: 0; padding: 0; }
+.attribution { padding-left: 1em; }
 </style>
-<script>
-var allThemes = [
-  { name: 'default' },
-  { name: 'desert',
-    authorHtml: '<a href="http://code.google.com/u/@VhJeSlJYBhVMWgF7/">'
-        + 'techto&hellip;@<\/a>' },
-  { name: 'sunburst', authorHtml: 'David Leibovic' },
-  { name: 'sons-of-obsidian',
-    authorHtml: '<a href="http://CodeTunnel.com/blog/post/71'
-        + '/google-code-prettify-obsidian-theme">Alex Ford<\/a>' },
-  { name: 'doxy', authorHtml: 'Robert Sperberg' },
-];
-
-// Called by the demo.html frames loaded per theme to
-// size the iframes properly and to allow them to tile
-// the page nicely.
+<script type="text/javascript">
+/**
+ * Called by the demo.html frames loaded per theme to size the iframes
+ * properly and to allow them to tile the page nicely.
+ */
 function adjustChildIframeSize(themeName, width, height) {
-  if (typeof console != 'undefined') {
+  if (typeof console !== 'undefined' && console.log) {
     try {
       console.log('adjusting ' + themeName + ' to ' + width + 'x' + height);
     } catch (ex) {
       // Don't bother logging log failure.
     }
   }
-
-  var container = document.getElementById(themeName).parentNode;
+  var iframe = document.getElementById(themeName);
+  iframe.style.height = (+height + 16) + 'px';
+  var container = iframe.parentNode;
   container.style.width = (+width + 16) + 'px';
   container.style.display = 'inline-block';
-  var iframe = container.getElementsByTagName('iframe')[0];
-  iframe.style.height = (+height + 16) + 'px';
+}
+
+/**
+ * Create an iframe to showcase theme.
+ * We pass the theme name to the iframe via its URI query, and it loads
+ * prettify and the theme CSS, and calls back to this page to resize iframe.
+ */
+function appendThemeIFrame(theme) {
+  // title
+  var link = document.createElement('a');
+  link.href = 'https://github.com/google/code-prettify/blob/master/' +
+    (theme.name === 'default' ? 'src/prettify.css' :
+    ('styles/' + encodeURIComponent(theme.name) + '.css'));
+  link.appendChild(document.createTextNode(
+    theme.name.replace(/\b[a-z]/g, function (letter) {
+      // Capitalize first letter of each word
+      return letter.toUpperCase();
+    })));
+  var header = document.createElement('h2');
+  header.className = 'title';
+  header.appendChild(link);
+
+  // attribution
+  var attribution;
+  if (theme.author) {
+    attribution = document.createElement('span');
+    attribution.className = 'attribution';
+    attribution.innerHTML = 'by <em>' + theme.author + '<\/em>';
+  }
+
+  // iframe
+  var iframe = document.createElement('iframe');
+  iframe.id = theme.name;
+  iframe.name = theme.name;  // theme name retrieved in demo.html
+  iframe.src = 'demo.html';
+  //iframe.src = 'demo.html?' + encodeURIComponent(theme.name);
+
+  // insert into page
+  var container = document.createElement('div');
+  container.className = 'container';
+  container.appendChild(header);
+  if (theme.author) { container.appendChild(attribution); }
+  container.appendChild(iframe);
+  document.body.appendChild(container);
 }
 </script>
 </head>
@@ -47,43 +81,23 @@ function adjustChildIframeSize(themeName, width, height) {
 Click on a theme name for a link to the file in revision control.
 Print preview this page to see how the themes work on the printed page.
 </p>
-<script>(function () {
+
+<script type="text/javascript">
+var allThemes = [
+  { name: 'default' },
+  { name: 'desert', author: '<a href="https://code.google.com/u/techtonik@gmail.com/">anatoly techtonik<\/a>' },
+  { name: 'sunburst', author: 'David Leibovic' },
+  { name: 'sons-of-obsidian', author: '<a href="http://CodeTunnel.com/blog/post/71/google-code-prettify-obsidian-theme">Alex Ford<\/a>' },
+  { name: 'doxy', author: 'Robert Sperberg' }
+];
+
+(function () {
   // Produce an iframe per theme.
-  // We pass the threme name to the iframe via its URI query, and
-  // it loads prettify and the theme CSS, and calls back to this page
-  // to resize the iframe.
   for (var i = 0, n = allThemes.length; i < n; ++i) {
-    var theme = allThemes[i];
-    if (!theme) { continue; }
-    var iframe = document.createElement('iframe');
-    iframe.name = theme.name;
-    iframe.src = 'demo.html?' + encodeURIComponent(theme.name);
-    var header = document.createElement('h2');
-    header.id = theme.name;
-    var linkToThemeSrc = document.createElement('a');
-    linkToThemeSrc.href = (
-        'https://cdn.rawgit.com/google/code-prettify/master/' +
-        (theme.name === 'default'
-         ? 'src/prettify.css'
-         : 'styles/' + encodeURIComponent(theme.name) + '.css'));
-    linkToThemeSrc.appendChild(document.createTextNode(
-       theme.name.replace(/\b[a-z]/g,  // Capitalize first letter of each word
-       function (letter) { return letter.toUpperCase(); })));
-    header.appendChild(linkToThemeSrc);
-
-    var attribution;
-    if (theme.authorHtml) {
-      attribution = document.createElement('span');
-      attribution.className = 'attribution';
-      attribution.innerHTML = 'by ' + theme.authorHtml;
-    }
-
-    var div = document.createElement('div');
-    div.appendChild(header);
-    if (attribution) { div.appendChild(attribution); }
-    div.appendChild(iframe);
-    document.body.appendChild(div);
+    appendThemeIFrame(allThemes[i]);
   }
-})()</script>
+})();
+</script>
 
-</body></html>
+</body>
+</html>

--- a/syntax/code.php
+++ b/syntax/code.php
@@ -13,11 +13,20 @@ if(!defined('DOKU_INC')) die();
 class syntax_plugin_codeprettify_code extends DokuWiki_Syntax_Plugin {
 
     protected $mode;
-    protected $entry_pattern = '<Code\b.*?>(?=.*?</Code>)';
-    protected $exit_pattern  = '</Code>';
+    protected $patterns;
 
     function __construct() {
         $this->mode = substr(get_class($this), 7);
+
+        // allowing nested "<angle pairs>" in title using regex atomic grouping
+        $n = 3;
+        $param = str_repeat('(?>[^<>\n]+|<', $n).str_repeat('>)*', $n);       
+
+        $this->patterns[0] = '<Code\b'.$param.'>'.'(?=.*?</Code>)';
+        $this->patterns[1] = '</Code>';
+
+        $this->patterns[2] = '<code\b.*?>(?=.*?</code>)';
+        $this->patterns[3] = '</code>';
     }
 
     public function getType() { return 'protected'; }
@@ -28,16 +37,16 @@ class syntax_plugin_codeprettify_code extends DokuWiki_Syntax_Plugin {
      * Connect pattern to lexer
      */
     public function connectTo($mode) {
-        $this->Lexer->addEntryPattern($this->entry_pattern, $mode, $this->mode);
+        $this->Lexer->addEntryPattern($this->patterns[0], $mode, $this->mode);
         if ($this->getConf('override')) {
-            $this->Lexer->addEntryPattern('<code\b.*?>(?=.*?</code>)', $mode, $this->mode);
+            $this->Lexer->addEntryPattern($this->patterns[2], $mode, $this->mode);
         }
     }
 
     public function postConnect() {
-        $this->Lexer->addExitPattern($this->exit_pattern, $this->mode);
+        $this->Lexer->addExitPattern($this->patterns[1], $this->mode);
         if ($this->getConf('override')) {
-            $this->Lexer->addExitPattern('</code>', $this->mode);
+            $this->Lexer->addExitPattern($this->patterns[3], $this->mode);
         }
     }
 


### PR DESCRIPTION
Allow angle-pair syntax such as `<sup>superscript</sup>` or `<fc red>text</fc>` in title.
```
usage: ex. <Code:css linenums:5 lang-css | H<sub>2</sub>O  > ... </Code>
```
This PR includes recent updates of Japascript code prettifier project around 2017-03-15

